### PR TITLE
fix: align checkAutoStart timer to 1500ms

### DIFF
--- a/src/PowerMgmt.be
+++ b/src/PowerMgmt.be
@@ -187,7 +187,7 @@ class PowerMgmt
       self.autoStartEnabled = true
       self.updateMode()
       tasmota.cmd("Power1 On")
-      tasmota.set_timer( int(1000), /-> self.checkAutoStart(), "CheckAutoStart")
+      tasmota.set_timer( int(1500), /-> self.checkAutoStart(), "CheckAutoStart")
     end
   end
 


### PR DESCRIPTION
## Summary

- `checkAutoStart` was scheduled at 1000ms from P1 ON, while the heating element takes ~1500ms to start drawing power
- At 1000ms the power reading was still 0W → auto-start skipped silently and never retried
- `checkPreloadPump` was already at 1500ms and correctly saw 384W
- Fixed by aligning both timers to 1500ms

## Root cause (from log analysis)
```
[PowerMgmt] P1 ON
[PowerMgmt] checkAutoStart | power=0W → skip     ← t=1000ms, too early
[PowerMgmt] checkPreloadPump | power=384W → skip  ← t=1500ms, already drawing
[PowerMgmt] status=Heating                         ← machine heats up normally
[PowerMgmt] status=Ready                           ← but brew never starts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)